### PR TITLE
[CONF] Set TimeZone configuration.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,10 @@ module DecidimAgustiIntApp
 
     config.active_job.queue_adapter = :delayed_job
 
+    config.time_zone = 'Madrid'
+    config.active_record.default_timezone = :local
+    config.active_record.time_zone_aware_attributes = false
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
Explicitly configure the TimeZone used by Rails as recomended here https://makandracards.com/makandra/46009-working-with-or-without-time-zones-in-rails-applications

to avoid problems with dates.