### PR TITLE
Set config for API schema

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -19,6 +19,10 @@ Decidim.configure do |config|
 
   # Image compression settings
   config.image_uploader_quality = 80
+
+  # API schema settings
+  Decidim::Api::Schema.max_complexity = 5000
+  Decidim::Api::Schema.max_depth = 50
 end
 
 # Inform Decidim about the assets folder


### PR DESCRIPTION
Add API Schema config to `decidim.rb` to show global map in a participatory process.

![image](https://user-images.githubusercontent.com/75725233/224725086-ca6187e6-fd2d-4549-8040-1940cf2c65de.png)
